### PR TITLE
docs: rewrite README with professional format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Web-based HL7 FHIR data validator with support for Japanese Implementation Guide
 ## Features
 
 - Validate FHIR resources against standard and custom profiles
-- Support for Japanese FHIR IGs: JP-Core, JP Terminology, JP ECS CLINS
+- Support for Japanese FHIR IGs: JP-Core, JP-FHIR Terminology, JP-eCSCLINS
 - Web UI for easy resource validation
 - REST API for programmatic access
 - Docker deployment
@@ -19,8 +19,8 @@ Web-based HL7 FHIR data validator with support for Japanese Implementation Guide
 | IG | Description |
 |----|-------------|
 | JP-Core | Japan Core FHIR profiles |
-| JP Terminology | Japanese medical terminology |
-| JP ECS CLINS | Clinical information sharing |
+| JP-FHIR Terminology | Japanese medical terminology |
+| JP-eCSCLINS | Clinical information sharing |
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# fhir-validator-app
+# fhir-validator-web
+
+![Python](https://img.shields.io/badge/Python-3776AB?style=flat-square&logo=python&logoColor=white)
+![Flask](https://img.shields.io/badge/Flask-000?style=flat-square&logo=flask&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white)
+
+Web-based HL7 FHIR data validator with support for Japanese Implementation Guides.
+
+## Features
+
+- Validate FHIR resources against standard and custom profiles
+- Support for Japanese FHIR IGs: JP-Core, JP Terminology, JP ECS CLINS
+- Web UI for easy resource validation
+- REST API for programmatic access
+- Docker deployment
+
+## Supported Implementation Guides
+
+| IG | Description |
+|----|-------------|
+| JP-Core | Japan Core FHIR profiles |
+| JP Terminology | Japanese medical terminology |
+| JP ECS CLINS | Clinical information sharing |
+
+## Tech Stack
+
+- **Backend**: Python Flask
+- **Validator**: HL7 FHIR Validator CLI (Java)
+- **Frontend**: HTML/CSS/JavaScript
+- **Deployment**: Docker
+
+## Prerequisites
+
+- Python 3.8+
+- Java 11+ (for FHIR Validator CLI)
+
+## Getting Started
+
+```bash
+cd backend && pip install -r requirements.txt
+python app.py
+```
+
+### Docker
+
+```bash
+docker build -t fhir-validator-web .
+docker run -p 5000:5000 fhir-validator-web
+```
+
+## License
+
+See [LICENSE](./LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -36,17 +36,30 @@ Web-based HL7 FHIR data validator with support for Japanese Implementation Guide
 
 ## Getting Started
 
-```bash
-cd backend && pip install -r requirements.txt
-python app.py
-```
-
-### Docker
+The recommended way to run the application locally is via Docker, which sets up
+the expected directory layout (including `/app/validator-data`) for you.
 
 ```bash
 docker build -t fhir-validator-web .
 docker run -p 5000:5000 fhir-validator-web
 ```
+
+### Running the backend without Docker (development only)
+
+If you want to run the backend directly on your host (for example, when
+developing), you can do:
+
+```bash
+cd backend
+pip install -r requirements.txt
+python app.py
+```
+
+Note: The backend currently expects its application root to be `/app` and
+resolves the `validator-data/` directory relative to that path, mirroring the
+Docker container layout. To run it reliably outside Docker, ensure that this
+directory structure and required data are available on your system, or prefer
+using the Docker-based workflow above.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Web-based HL7 FHIR data validator with support for Japanese Implementation Guide
 ## Prerequisites
 
 - Python 3.8+
-- Java 11+ (for FHIR Validator CLI)
+- Java 17+ (for FHIR Validator CLI; the Docker image includes the required Java runtime)
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- Replace old README with clean, professional format
- Add tech stack badges, feature list, and setup instructions
- Remove spy/agent theme